### PR TITLE
Don't try to compare if decimal value is nil.

### DIFF
--- a/lib/ib/support.rb
+++ b/lib/ib/support.rb
@@ -29,13 +29,17 @@ module IBSupport
 		## Values -1 and below indicate: Not computed (TickOptionComputation)
 		def read_decimal_limit_1
 			i= read_float
-			i <= -1 ? nil : i
+      return nil if i.nil?
+      return nil if i <= -1
+      i
 		end
 
 		## Values -2 and below indicate: Not computed (TickOptionComputation)
 		def read_decimal_limit_2
 			i= read_float
-			i <= -2 ? nil : i
+      return nil if i.nil?
+      return nil if i <= -2
+      i
 		end
 
 


### PR DESCRIPTION
Gem fails reading opton greeks if a decimal value is empty:


> Traceback (most recent call last):                                                                                                                                                                                           > 12: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/connection.rb:381:in `block in start_reader'                                                                                                                    11: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/connection.rb:297:in `process_messages'                                                                                                                         10: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/connection.rb:401:in `process_message'                                                                                                                           9: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/socket.rb:101:in `decode_message'                                                                                                                                8: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/connection.rb:413:in `block in process_message'                                                                                                                  7: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/connection.rb:413:in `new'                                                                                                                                       6: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:41:in `initialize'                                                                                                         5: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:63:in `load'                                                                                                               4: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:52:in `simple_load'                                                                                                        3: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:73:in `load_map'                                                                                                           2: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:73:in `each'                                                                                                               1: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:96:in `block in load_map'                                                                                         /home/metrix/.gems/gems/ib-api-972.5/lib/ib/support.rb:38:in `read_decimal_limit_2': undefined method `<=' for nil:NilClass (NoMethodError)                                                                                  13: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/connection.rb:381:in `block in start_reader'         12: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/connection.rb:297:in `process_messages'              11: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/connection.rb:401:in `process_message'                                                                                                                          10: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/socket.rb:101:in `decode_message'                     9: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/connection.rb:413:in `block in process_message'                                                                                                                  8: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/connection.rb:413:in `new'                                                                                                                                       7: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:41:in `initialize'         6: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:63:in `load'                                                                                                               5: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:52:in `simple_load'                                                                                                        4: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:73:in `load_map'                                                                                                           3: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:73:in `each'                                                                                                               2: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:95:in `block in load_map'                                                                                                  1: from /home/metrix/.gems/gems/ib-api-972.5/lib/ib/messages/incoming/abstract_message.rb:98:in `rescue in block in load_map'                                                                               /home/metrix/.gems/gems/ib-api-972.5/lib/ib/errors.rb:43:in `error': Reading IB::Messages::Incoming::TickOption: NoMethodError: undefined method `<=' for nil:NilClass  --> Instruction: vega (IB::TransmissionError)
