### PR TITLE
[WIP] Properly handle multiple messages in a buffer

### DIFF
--- a/lib/ib/raw_message.rb
+++ b/lib/ib/raw_message.rb
@@ -10,7 +10,7 @@ module IB
       @data = String.new
     end
 
-    def process
+    def each
       while true
       append_new_data
 

--- a/lib/ib/raw_message.rb
+++ b/lib/ib/raw_message.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+module IB
+  # Convert data passed in from a TCP socket stream, and convert into
+  # raw messages. The messages
+  class RawMessageParser
+    HEADER_LNGTH = 4
+    def initialize(socket)
+      @socket = socket
+      @data = String.new
+    end
+
+    def process
+      while true
+      append_new_data
+
+      next unless length_data?
+      next unless enough_data?
+
+      length = next_msg_length
+      validate_data_header(length)
+
+      raw = grab_message(length)
+      validate_message_footer(raw, length)
+      msg = parse_message(raw, length)
+      remove_message
+      yield msg
+      end
+    end
+
+    # extract message and convert to
+    # an array split by null characters.
+    def grab_message(length)
+      @data.byteslice(HEADER_LNGTH, length)
+    end
+
+    def parse_message(raw, length)
+      raw.unpack1("A#{length}").split("\0")
+    end
+
+    def remove_message
+      length = next_msg_length
+      leftovers = @data.byteslice(length + HEADER_LNGTH..-1)
+      @data = if leftovers.nil?
+                String.new
+              else
+                leftovers
+              end
+    end
+
+    def enough_data?
+      actual_lngth = next_msg_length + HEADER_LNGTH
+      echo 'too little data' if next_msg_length.nil?
+      return false if next_msg_length.nil?
+      @data.bytesize >= actual_lngth
+    end
+
+    def length_data?
+      @data.bytesize > HEADER_LNGTH
+    end
+
+    def next_msg_length
+      #can't check length if first 4 bytes don't exist
+      length = @data.byteslice(0..3).unpack1('N')
+      return 0 if length.nil?
+      length
+    end
+
+    def append_new_data
+      @data += @socket.recv_from
+    end
+
+    def validate_message_footer(msg,length)
+      last = msg.bytesize
+      last_byte = msg.byteslice(last-1,last)
+      raise 'Could not validate last byte' if last_byte.nil?
+      raise "Message has an invalid last byte. expecting \0, received: #{last_byte}" if last_byte != "\0"
+    end
+
+    def validate_data_header(length)
+      return true if length <= 5000
+      raise 'Message is longer than sane max length'
+    end
+  end
+end

--- a/spec/ib/raw_message.rb
+++ b/spec/ib/raw_message.rb
@@ -12,7 +12,7 @@ RSpec.describe IB::RawMessageParser do
 
     parser = IB::RawMessageParser.new(socket)
     counter = 0
-    parser.process do |message|
+    parser.each do |message|
       expect(message).to eq(VALID_MESSAGE)
       break if counter >= 1
 
@@ -30,7 +30,7 @@ RSpec.describe IB::RawMessageParser do
 
     parser = IB::RawMessageParser.new(socket)
     counter = 0
-    parser.process do |message|
+    parser.each do |message|
       expect(message).to eq(VALID_MESSAGE)
 
       counter += 1
@@ -50,7 +50,7 @@ RSpec.describe IB::RawMessageParser do
 
     parser = IB::RawMessageParser.new(socket)
     counter = 0
-    parser.process do |message|
+    parser.each do |message|
       expect(message).to eq(VALID_MESSAGE)
 
       counter += 1
@@ -68,7 +68,7 @@ RSpec.describe IB::RawMessageParser do
 
     parser = IB::RawMessageParser.new(socket)
     counter = 0
-    parser.process do |message|
+    parser.each do |message|
       expect(message).to eq(VALID_MESSAGE)
       break if counter >= test_message_count
 
@@ -87,7 +87,7 @@ RSpec.describe IB::RawMessageParser do
 
     parser = IB::RawMessageParser.new(socket)
     counter = 0
-    parser.process do |message|
+    parser.each do |message|
       expect(message).to eq(VALID_MESSAGE)
       break if counter >= test_message_count
 
@@ -103,6 +103,6 @@ RSpec.describe IB::RawMessageParser do
     allow(socket).to receive(:recv_from).and_return(bad_message)
 
     parser = IB::RawMessageParser.new(socket)
-    expect { parser.process { |msg| } }.to raise_error(StandardError, /invalid last byte/)
+    expect { parser.each { |msg| } }.to raise_error(StandardError, /invalid last byte/)
   end
 end

--- a/spec/ib/raw_message.rb
+++ b/spec/ib/raw_message.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require_relative '../../lib/ib/raw_message'
+
+VALID_MESSAGE = ['137', '20220719 18:46:24 Central Standard Time'].freeze
+RSpec.describe IB::RawMessageParser do
+  it 'Parser Receives a full message from the TCP Socket' do
+    test_message_count = 1
+    full_message = "\x00\x00\x00,137\x0020220719 18:46:24 Central Standard Time\x00"
+    socket = double
+    allow(socket).to receive(:recv_from).and_return(full_message, 'x')
+
+    parser = IB::RawMessageParser.new(socket)
+    counter = 0
+    parser.process do |message|
+      expect(message).to eq(VALID_MESSAGE)
+      break if counter >= 1
+
+      counter += 1
+      break if counter >= test_message_count
+    end
+  end
+
+  it 'Parser Receives a full message in two chunks from the TCP Socket' do
+    test_message_count = 1
+    part_a = "\x00\x00\x00,137\x002022"
+    part_b = "0719 18:46:24 Central Standard Time\x00"
+    socket = double
+    allow(socket).to receive(:recv_from).and_return(part_a, part_b, 'x')
+
+    parser = IB::RawMessageParser.new(socket)
+    counter = 0
+    parser.process do |message|
+      expect(message).to eq(VALID_MESSAGE)
+
+      counter += 1
+      break if counter >= test_message_count
+    end
+    # make sure the proper number of messages 
+    # are processed.
+    expect(counter).to eq (test_message_count)
+  end
+
+  it 'Parser Receives two full messages' do
+    test_message_count = 2
+    full_message_a = "\x00\x00\x00,137\x0020220719 18:46:24 Central Standard Time\x00"
+    full_message_b = "\x00\x00\x00,137\x0020220719 18:46:24 Central Standard Time\x00"
+    socket = double
+    allow(socket).to receive(:recv_from).and_return(full_message_a, full_message_b, 'x')
+
+    parser = IB::RawMessageParser.new(socket)
+    counter = 0
+    parser.process do |message|
+      expect(message).to eq(VALID_MESSAGE)
+
+      counter += 1
+      break if counter >= test_message_count
+    end
+    expect(counter).to eq (test_message_count)
+  end
+
+  it 'Parser Receives a full message and a half, the rest in chunk b ' do
+    test_message_count = 2
+    full_message = "\x00\x00\x00,137\x0020220719 18:46:24 Central Standard Time\x00\x00\x00\x00,137\x002022"
+    part_message = "0719 18:46:24 Central Standard Time\x00"
+    socket = double
+    allow(socket).to receive(:recv_from).and_return(full_message, part_message, 'x')
+
+    parser = IB::RawMessageParser.new(socket)
+    counter = 0
+    parser.process do |message|
+      expect(message).to eq(VALID_MESSAGE)
+      break if counter >= test_message_count
+
+      counter += 1
+      break if counter >= test_message_count
+    end
+    expect(counter).to eq(test_message_count)
+  end
+
+  it 'Parser Receives a full message and the first byte of a second, the rest in chunk b ' do
+    test_message_count = 2
+    full_message = "\x00\x00\x00,137\x0020220719 18:46:24 Central Standard Time\x00\x00"
+    part_message = "\x00\x00,137\x0020220719 18:46:24 Central Standard Time\x00"
+    socket = double
+    allow(socket).to receive(:recv_from).and_return(full_message, part_message, 'x')
+
+    parser = IB::RawMessageParser.new(socket)
+    counter = 0
+    parser.process do |message|
+      expect(message).to eq(VALID_MESSAGE)
+      break if counter >= test_message_count
+
+      counter += 1
+      break if counter >= test_message_count
+    end
+    expect(counter).to eq(test_message_count)
+  end
+
+  bad_message = "\x00\x00\x00,137\x0020220719 18:46:24 Central Standard Time\x01"
+  it 'Parser Receives an invalid message (last byte is not \\x00)' do
+    socket = double
+    allow(socket).to receive(:recv_from).and_return(bad_message)
+
+    parser = IB::RawMessageParser.new(socket)
+    expect { parser.process { |msg| } }.to raise_error(StandardError, /invalid last byte/)
+  end
+end


### PR DESCRIPTION
The library crashes when the TCPSocket happens to have more than one message in stored in the buffer.  The reason for this is that the socket is reading in a stream of bytes, and does not understand the beginning or ending of a message.  The socket could have half a message, multiple messages, or 1 and half messages.  It's up to the library to parse this out.

My current solution is to read data from the socket, append it to data leftover from the previous call (if any) and to return a single message out of the queue if data is available. 

The current WIP breaks down if multiple messages happen to be in the queue, so the current workaround is to drop the number of bytes returned from a `recvfrom` to 20 - It could be any number less than the size of the smallest message.  



