### PR TITLE
[BugFix] [Small improvement] Update connection.rb

### DIFF
--- a/lib/ib/connection.rb
+++ b/lib/ib/connection.rb
@@ -284,23 +284,25 @@ module IB
       begin
       while (time_left = time_out - Time.now) > 0
         # If socket is readable, process single incoming message
-				#process_message if select [socket], nil, nil, time_left
-				# the following  checks for shutdown of TWS side; ensures we don't run in a spin loop.
-				# unfortunately, it raises Errors in windows environment
-        if select [socket], nil, nil, time_left
-        #  # Peek at the message from the socket; if it's blank then the
-        #  # server side of connection (TWS) has likely shut down.
-          socket_likely_shutdown = socket.recvmsg(100, Socket::MSG_PEEK)[0] == ""
-				#
-        #  # We go ahead process messages regardless (a no-op if socket_likely_shutdown).
-          process_message
-        #
-        #  # After processing, if socket has shut down we sleep for 100ms
-        #  # to avoid spinning in a tight loop. If the server side somehow
-        #  # comes back up (gets reconnedted), normal processing
-        #  # (without the 100ms wait) should happen.
-         sleep(0.1) if socket_likely_shutdown
-        end
+	process_message if select [socket], nil, nil, time_left
+	# the following  checks for shutdown of TWS side; ensures we don't run in a spin loop.
+	# unfortunately, it raises Errors in windows environment
+        unless RUBY_PLATFORM.match(/cygwin|mswin|mingw|bccwin|wince|emx/)	  
+	  if select [socket], nil, nil, time_left
+            #  # Peek at the message from the socket; if it's blank then the
+            #  # server side of connection (TWS) has likely shut down.
+            socket_likely_shutdown = socket.recvmsg(100, Socket::MSG_PEEK)[0] == ""
+	    #
+            #  # We go ahead process messages regardless (a no-op if socket_likely_shutdown).
+            process_message
+            #
+            #  # After processing, if socket has shut down we sleep for 100ms
+            #  # to avoid spinning in a tight loop. If the server side somehow
+            #  # comes back up (gets reconnedted), normal processing
+            #  # (without the 100ms wait) should happen.
+            sleep(0.1) if socket_likely_shutdown
+          end
+      	end
       end
       rescue Errno::ECONNRESET => e
         logger.fatal e.message


### PR DESCRIPTION
- line [287] removed comment # to reinstate line - commenting it out led to stall in Windows environment (seems like a typo) 
- line [290], [305]  added "unless" check for Windows environment, ignores check for TWS shutdown in windows environment (functionality does not work in Windows environment)